### PR TITLE
Support azurite emulator & Default Azure Credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+test/data/whatever.pdf

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install
 
 Provide Azure Blob Storage configurations, as environment variables:
 
-### Authorization with Shared Key (for local developpemen not recommended for Container app production deployement)
+### Authorization with Shared Key (for local development not recommended for Container app production deployment)
 ```dotenv
 AZURE_STORAGE_ACCOUNT=STORAGE_ACCOUNT_NAME
 AZURE_STORAGE_KEY=STORAGE_ACCOUNT_KEY
@@ -51,9 +51,35 @@ CONTAINER_RENDERS=STORAGE_RENDERS_CONTAINER
 ### Authorization with User managed Identity
 ```dotenv
 AZURE_STORAGE_ACCOUNT=STORAGE_ACCOUNT_NAME
-AZURE_MANAGED_IDENTITY_CLIENT_ID="Client ID of user_assigned_identity
+AZURE_MANAGED_IDENTITY_CLIENT_ID="Client ID of user_assigned_identity"
 CONTAINER_TEMPLATES=STORAGE_CONTAINER_TEMPLATES
 CONTAINER_RENDERS=STORAGE_RENDERS_CONTAINER
+```
+
+### Authorization with Default Azure Credentials
+```dotenv
+AZURE_STORAGE_ACCOUNT=STORAGE_ACCOUNT_NAME
+AZURE_USE_DEFAULT_AZURE_CREDENTIALS="true"
+CONTAINER_TEMPLATES=STORAGE_CONTAINER_TEMPLATES
+CONTAINER_RENDERS=STORAGE_RENDERS_CONTAINER
+```
+
+Then set the additional environment variables that are needed for DefaultAzureCredential to work. They are [documented here](https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme?view=azure-node-latest#environment-variables).
+
+### Connection to azure storage emulators
+
+When using local emulators, use `AZURE_STORAGE_CONNECTION_STRING` instead of `AZURE_STORAGE_ACCOUNT`:
+
+```dotenv
+AZURE_STORAGE_CONNECTION_STRING=<connection string>
+CONTAINER_TEMPLATES=STORAGE_CONTAINER_TEMPLATES
+CONTAINER_RENDERS=STORAGE_RENDERS_CONTAINER
+```
+
+The azurite emulator default connection string can be [found here](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite#production-style-url):
+
+```
+DefaultEndpointsProtocol=http;AccountName=account1;AccountKey=key1;BlobEndpoint=http://account1.blob.localhost:10000;QueueEndpoint=http://account1.queue.localhost:10001;TableEndpoint=http://account1.table.localhost:10002;
 ```
 
 ## Strict mode

--- a/config.js
+++ b/config.js
@@ -13,25 +13,45 @@ function getConfig() {
       config = {};
     }
   }
-  if (process?.env?.AZURE_STORAGE_ACCOUNT && process?.env?.AZURE_STORAGE_KEY) {
+
+  if (process?.env?.AZURE_STORAGE_CONNECTION_STRING) {
     config.storageCredentials = {
-      accountName: process.env.AZURE_STORAGE_ACCOUNT,
-      accountKey: process.env.AZURE_STORAGE_KEY
+      type: "ConnectionString",
+      connectionString: process.env.AZURE_STORAGE_CONNECTION_STRING
     }
-  } else if (process?.env?.AZURE_STORAGE_ACCOUNT) {
-    if (process?.env?.AZURE_MANAGED_IDENTITY_CLIENT_ID) {
-      console.log('Storage authentication with Managed Identity user-assigned');
+  }
+  else {
+    if (process?.env?.AZURE_STORAGE_ACCOUNT && process?.env?.AZURE_STORAGE_KEY) {
       config.storageCredentials = {
+        type: "SharedKey",
         accountName: process.env.AZURE_STORAGE_ACCOUNT,
-        identityClientId: process.env.AZURE_MANAGED_IDENTITY_CLIENT_ID
+        accountKey: process.env.AZURE_STORAGE_KEY
       }
-    } else {
-      console.log('Storage authentication with Managed Identity system-assigned');
-      config.storageCredentials = {
-        accountName: process.env.AZURE_STORAGE_ACCOUNT
+    } else if (process?.env?.AZURE_STORAGE_ACCOUNT) {
+      if (process?.env?.AZURE_USE_DEFAULT_AZURE_CREDENTIALS === "true") {
+        console.log('Storage authentication with DefaultAzureCredential');
+        config.storageCredentials = {
+          type: "DefaultAzureCredential",
+          accountName: process.env.AZURE_STORAGE_ACCOUNT
+        }
+      }
+      else if  (process?.env?.AZURE_MANAGED_IDENTITY_CLIENT_ID) {
+        console.log('Storage authentication with Managed Identity user-assigned');
+        config.storageCredentials = {
+          type: "UserManagedIdentity",
+          accountName: process.env.AZURE_STORAGE_ACCOUNT,
+          identityClientId: process.env.AZURE_MANAGED_IDENTITY_CLIENT_ID
+        }
+      } else {
+        console.log('Storage authentication with Managed Identity system-assigned');
+        config.storageCredentials = {
+          type: "SystemManagedIdentity",
+          accountName: process.env.AZURE_STORAGE_ACCOUNT
+        }
       }
     }
   }
+
   if (process?.env?.CONTAINER_RENDERS) {
     config.rendersContainer = process.env.CONTAINER_RENDERS
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1656 @@
+{
+    "name": "carbone-ee-plugin-azure-storage-blob",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "dependencies": {
+                "@azure/identity": "^4.12.0",
+                "@azure/storage-blob": "^12.27.0",
+                "dotenv": "^16.5.0"
+            },
+            "devDependencies": {
+                "mocha": "^10.8.2",
+                "nock": "=13.5.0"
+            }
+        },
+        "node_modules/@azure/abort-controller": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+            "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-auth": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+            "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-util": "^1.13.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-client": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+            "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.10.0",
+                "@azure/core-rest-pipeline": "^1.22.0",
+                "@azure/core-tracing": "^1.3.0",
+                "@azure/core-util": "^1.13.0",
+                "@azure/logger": "^1.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-http-compat": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-http-compat/-/core-http-compat-2.4.0.tgz",
+            "integrity": "sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@azure/core-client": "^1.10.0",
+                "@azure/core-rest-pipeline": "^1.22.0"
+            }
+        },
+        "node_modules/@azure/core-lro": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-2.7.2.tgz",
+            "integrity": "sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-util": "^1.2.0",
+                "@azure/logger": "^1.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-paging": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+            "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@azure/core-rest-pipeline": {
+            "version": "1.23.0",
+            "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+            "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.10.0",
+                "@azure/core-tracing": "^1.3.0",
+                "@azure/core-util": "^1.13.0",
+                "@azure/logger": "^1.3.0",
+                "@typespec/ts-http-runtime": "^0.3.4",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-tracing": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+            "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-util": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+            "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/core-xml": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+            "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-xml-parser": "^5.5.9",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/identity": {
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+            "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.0.0",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-client": "^1.9.2",
+                "@azure/core-rest-pipeline": "^1.17.0",
+                "@azure/core-tracing": "^1.0.0",
+                "@azure/core-util": "^1.11.0",
+                "@azure/logger": "^1.0.0",
+                "@azure/msal-browser": "^5.5.0",
+                "@azure/msal-node": "^5.1.0",
+                "open": "^10.1.0",
+                "tslib": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/logger": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+            "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+            "license": "MIT",
+            "dependencies": {
+                "@typespec/ts-http-runtime": "^0.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/msal-browser": {
+            "version": "5.11.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.11.0.tgz",
+            "integrity": "sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/msal-common": "16.6.2"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-common": {
+            "version": "16.6.2",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.6.2.tgz",
+            "integrity": "sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@azure/msal-node": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.2.tgz",
+            "integrity": "sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/msal-common": "16.6.2",
+                "jsonwebtoken": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@azure/storage-blob": {
+            "version": "12.31.0",
+            "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.31.0.tgz",
+            "integrity": "sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-client": "^1.9.3",
+                "@azure/core-http-compat": "^2.2.0",
+                "@azure/core-lro": "^2.2.0",
+                "@azure/core-paging": "^1.6.2",
+                "@azure/core-rest-pipeline": "^1.19.1",
+                "@azure/core-tracing": "^1.2.0",
+                "@azure/core-util": "^1.11.0",
+                "@azure/core-xml": "^1.4.5",
+                "@azure/logger": "^1.1.4",
+                "@azure/storage-common": "^12.3.0",
+                "events": "^3.0.0",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@azure/storage-common": {
+            "version": "12.3.0",
+            "resolved": "https://registry.npmjs.org/@azure/storage-common/-/storage-common-12.3.0.tgz",
+            "integrity": "sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@azure/abort-controller": "^2.1.2",
+                "@azure/core-auth": "^1.9.0",
+                "@azure/core-http-compat": "^2.2.0",
+                "@azure/core-rest-pipeline": "^1.19.1",
+                "@azure/core-tracing": "^1.2.0",
+                "@azure/core-util": "^1.11.0",
+                "@azure/logger": "^1.1.4",
+                "events": "^3.3.0",
+                "tslib": "^2.8.1"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+            "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/@typespec/ts-http-runtime": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+            "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+            "license": "MIT",
+            "dependencies": {
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/ansi-colors": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+            "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/binary-extensions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/braces": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fill-range": "^7.1.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+            "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+            "license": "BSD-3-Clause"
+        },
+        "node_modules/bundle-name": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+            "license": "MIT",
+            "dependencies": {
+                "run-applescript": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/camelcase": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/cliui": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.0",
+                "wrap-ansi": "^7.0.0"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/decamelize": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+            "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+            "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+            "license": "MIT",
+            "dependencies": {
+                "bundle-name": "^4.1.0",
+                "default-browser-id": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+            "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/diff": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/escalade": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.x"
+            }
+        },
+        "node_modules/fast-xml-builder": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+            "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "path-expression-matcher": "^1.5.0",
+                "xml-naming": "^0.1.0"
+            }
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+            "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.2.0",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.3.0",
+                "xml-naming": "^0.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
+        "node_modules/fill-range": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/flat": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "bin": {
+                "flat": "cli.js"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/glob": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^5.0.1",
+                "once": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/he": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+            "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "he": "bin/he"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-extglob": "^2.1.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-unicode-supported": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+            "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+            "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+            "license": "MIT",
+            "dependencies": {
+                "is-inside-container": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/js-yaml": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/jsonwebtoken": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+            "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+            "license": "MIT",
+            "dependencies": {
+                "jws": "^4.0.1",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            }
+        },
+        "node_modules/jwa": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+            "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-equal-constant-time": "^1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jws": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+            "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+            "license": "MIT",
+            "dependencies": {
+                "jwa": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-locate": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+            "license": "MIT"
+        },
+        "node_modules/lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+            "license": "MIT"
+        },
+        "node_modules/log-symbols": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+            "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.0",
+                "is-unicode-supported": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/mocha": {
+            "version": "10.8.2",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+            "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-colors": "^4.1.3",
+                "browser-stdout": "^1.3.1",
+                "chokidar": "^3.5.3",
+                "debug": "^4.3.5",
+                "diff": "^5.2.0",
+                "escape-string-regexp": "^4.0.0",
+                "find-up": "^5.0.0",
+                "glob": "^8.1.0",
+                "he": "^1.2.0",
+                "js-yaml": "^4.1.0",
+                "log-symbols": "^4.1.0",
+                "minimatch": "^5.1.6",
+                "ms": "^2.1.3",
+                "serialize-javascript": "^6.0.2",
+                "strip-json-comments": "^3.1.1",
+                "supports-color": "^8.1.1",
+                "workerpool": "^6.5.1",
+                "yargs": "^16.2.0",
+                "yargs-parser": "^20.2.9",
+                "yargs-unparser": "^2.0.0"
+            },
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha.js"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "license": "MIT"
+        },
+        "node_modules/nock": {
+            "version": "13.5.0",
+            "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.0.tgz",
+            "integrity": "sha512-9hc1eCS2HtOz+sE9W7JQw/tXJktg0zoPSu48s/pYe73e25JW9ywiowbqnUSd7iZPeVawLcVpPZeZS312fwSY+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.1.0",
+                "json-stringify-safe": "^5.0.1",
+                "propagate": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13"
+            }
+        },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/open": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+            "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+            "license": "MIT",
+            "dependencies": {
+                "default-browser": "^5.2.1",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "wsl-utils": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-limit": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "yocto-queue": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "p-limit": "^3.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/path-expression-matcher": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/picomatch": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/propagate": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+            "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+            "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/semver": {
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/serialize-javascript": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/strnum": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+            "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
+            }
+        },
+        "node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
+        },
+        "node_modules/workerpool": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+            "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/wsl-utils": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+            "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+            "license": "MIT",
+            "dependencies": {
+                "is-wsl": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/xml-naming": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+            "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "16.2.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+            "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^7.0.2",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.0",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^20.2.2"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "20.2.9",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs-unparser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+            "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "camelcase": "^6.0.0",
+                "decamelize": "^4.0.0",
+                "flat": "^5.0.2",
+                "is-plain-obj": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yocto-queue": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        }
+    }
+}

--- a/storage.js
+++ b/storage.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { BlobServiceClient, StorageSharedKeyCredential } = require('@azure/storage-blob');
-const { ManagedIdentityCredential } = require('@azure/identity');
+const { ManagedIdentityCredential, DefaultAzureCredential } = require('@azure/identity');
 const config = require('./config');
 
 const _config = config.getConfig();
@@ -12,23 +12,33 @@ let blobServiceClient;
 console.log("Init plugin");
 
 if (_config?.storageCredentials) {
-  if (_config?.storageCredentials?.accountKey ) {
-    const sharedKeyCredential = new StorageSharedKeyCredential(
-      _config.storageCredentials.accountName,
-      _config.storageCredentials.accountKey
-    );
-
-    blobServiceClient = new BlobServiceClient(
-      `https://${_config.storageCredentials.accountName}.blob.core.windows.net`,
-      sharedKeyCredential);
-  } else {
+  if (_config.storageCredentials.type === "ConnectionString") {
+    blobServiceClient = BlobServiceClient.fromConnectionString(_config.storageCredentials.connectionString);
+  }
+  else {
     let credential;
-    if (_config?.storageCredentials?.identityClientId) {
-      credential = new ManagedIdentityCredential({
-        clientId: _config.storageCredentials.identityClientId,
-      });
-    } else {
-      credential = new ManagedIdentityCredential();
+
+    switch (_config.storageCredentials.type) {
+      case "SharedKey":
+        credential = new StorageSharedKeyCredential(
+          _config.storageCredentials.accountName,
+          _config.storageCredentials.accountKey
+        );
+        break;
+
+      case "DefaultAzureCredential":
+        credential = new DefaultAzureCredential();
+        break;
+
+      case "UserManagedIdentity":
+        credential = new ManagedIdentityCredential({
+          clientId: _config.storageCredentials.identityClientId,
+        });
+        break;
+
+      case "SystemManagedIdentity":
+        credential = new ManagedIdentityCredential();
+        break;
     }
 
     blobServiceClient = new BlobServiceClient(
@@ -211,7 +221,7 @@ function readRender(req, res, renderId, callback) {
         .catch(err => {
           return callback(new Error(`Error downloading blob: ${err.message}`));
         });
-    } 
+    }
     else {
       return blobClient.delete()
         .then(() => {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,28 +1,61 @@
 const config = require('../config');
 const assert = require('assert');
 
+const envKeys = [
+    'AZURE_STORAGE_CONNECTION_STRING',
+    'AZURE_STORAGE_ACCOUNT',
+    'AZURE_STORAGE_KEY',
+    'AZURE_USE_DEFAULT_AZURE_CREDENTIALS',
+    'AZURE_MANAGED_IDENTITY_CLIENT_ID',
+    'CONTAINER_RENDERS',
+    'CONTAINER_TEMPLATES',
+    'CARBONE_AST_CONFIG',
+    'CARBONE_AST_CONFIG_PATH',
+    'STORAGE_STRICT_MODE'
+];
+
+function resetEnv() {
+    for (const key of envKeys) {
+        delete process.env[key];
+    }
+}
+
 describe('Config', () => {
 
+    beforeEach(() => {
+        resetEnv();
+        config.setConfig(null);
+    });
+
+    afterEach(() => {
+        resetEnv();
+        config.setConfig(null);
+    });
+
     it('should return an empty object if config.json does not exist and environment variables are not set.', () => {
-        delete process.env.AZURE_STORAGE_ACCOUNT;
-        delete process.env.AZURE_STORAGE_KEY;
-        delete process.env.CONTAINER_RENDERS;
-        delete process.env.CONTAINER_TEMPLATES;
         config.setConfig({});
         const _config = config.getConfig();
-        assert.deepStrictEqual(_config, {}); 
+        assert.deepStrictEqual(_config, {
+            storage_strict_mode: 'false'
+        });
     })
 
     it('should set a custom config', () => {
-        const _expectedConfig = {
+        const _customConfig = {
             storageCredentials: {
+                type: 'SharedKey',
                 accountName: 'whateverAccountName',
                 accountKey: 'whateverAccountKey'
             },
             rendersContainer: 'whateverRendersContainer',
             templatesContainer: 'whateverTemplatesContainer'
-        }
-        config.setConfig(_expectedConfig);
+        };
+        const _expectedConfig = {
+            ..._customConfig,
+            storage_strict_mode: 'false'
+        };
+
+        config.setConfig(_customConfig);
         const _config = config.getConfig();
         assert.deepStrictEqual(_config, _expectedConfig);
     })
@@ -32,11 +65,13 @@ describe('Config', () => {
         process.env.CARBONE_AST_CONFIG_PATH = './test/data'
 
         config.setConfig(null);
-        const _expectedConfig = require('./data/config.test.json')
+        const _fileConfig = require('./data/config.test.json');
+        const _expectedConfig = {
+            ..._fileConfig,
+            storage_strict_mode: 'false'
+        };
         const _config = config.getConfig();
         assert.deepStrictEqual(_config, _expectedConfig);
-        delete process.env.CARBONE_AST_CONFIG;
-        delete process.env.CARBONE_AST_CONFIG_PATH;
     })
 
     it('should load configuration from environment variables', () => {
@@ -47,18 +82,86 @@ describe('Config', () => {
         process.env.CONTAINER_TEMPLATES = 'whateverTemplatesContainer'
         const _expectedConfig = {
             "storageCredentials": {
+                "type": "SharedKey",
                 "accountName": "whateverAccountName",
                 "accountKey": "whateverAccountKey"
             },
             "rendersContainer": "whateverRendersContainer",
-            "templatesContainer": "whateverTemplatesContainer"
+            "templatesContainer": "whateverTemplatesContainer",
+            "storage_strict_mode": "false"
         }
         const _config = config.getConfig();
         assert.deepStrictEqual(_config, _expectedConfig);
-        delete process.env.AZURE_STORAGE_ACCOUNT;
-        delete process.env.AZURE_STORAGE_KEY;
-        delete process.env.CONTAINER_RENDERS;
-        delete process.env.CONTAINER_TEMPLATES;
+    })
+
+    it('should load configuration with DefaultAzureCredential from environment variables', () => {
+        config.setConfig({});
+        process.env.AZURE_STORAGE_ACCOUNT = 'whateverAccountName';
+        process.env.AZURE_USE_DEFAULT_AZURE_CREDENTIALS = 'true';
+        process.env.CONTAINER_RENDERS = 'whateverRendersContainer';
+        process.env.CONTAINER_TEMPLATES = 'whateverTemplatesContainer';
+
+        const _expectedConfig = {
+            storageCredentials: {
+                type: 'DefaultAzureCredential',
+                accountName: 'whateverAccountName'
+            },
+            rendersContainer: 'whateverRendersContainer',
+            templatesContainer: 'whateverTemplatesContainer',
+            storage_strict_mode: 'false'
+        };
+
+        const _config = config.getConfig();
+        assert.deepStrictEqual(_config, _expectedConfig);
+    })
+
+    it('should load configuration with UserManagedIdentity from environment variables', () => {
+        config.setConfig({});
+        process.env.AZURE_STORAGE_ACCOUNT = 'whateverAccountName';
+        process.env.AZURE_MANAGED_IDENTITY_CLIENT_ID = 'whateverIdentityClientId';
+        process.env.CONTAINER_RENDERS = 'whateverRendersContainer';
+        process.env.CONTAINER_TEMPLATES = 'whateverTemplatesContainer';
+
+        const _expectedConfig = {
+            storageCredentials: {
+                type: 'UserManagedIdentity',
+                accountName: 'whateverAccountName',
+                identityClientId: 'whateverIdentityClientId'
+            },
+            rendersContainer: 'whateverRendersContainer',
+            templatesContainer: 'whateverTemplatesContainer',
+            storage_strict_mode: 'false'
+        };
+
+        const _config = config.getConfig();
+        assert.deepStrictEqual(_config, _expectedConfig);
+    })
+
+    it('should load configuration with SystemManagedIdentity from environment variables', () => {
+        config.setConfig({});
+        process.env.AZURE_STORAGE_ACCOUNT = 'whateverAccountName';
+        process.env.CONTAINER_RENDERS = 'whateverRendersContainer';
+        process.env.CONTAINER_TEMPLATES = 'whateverTemplatesContainer';
+
+        const _expectedConfig = {
+            storageCredentials: {
+                type: 'SystemManagedIdentity',
+                accountName: 'whateverAccountName'
+            },
+            rendersContainer: 'whateverRendersContainer',
+            templatesContainer: 'whateverTemplatesContainer',
+            storage_strict_mode: 'false'
+        };
+
+        const _config = config.getConfig();
+        assert.deepStrictEqual(_config, _expectedConfig);
+    })
+
+    it('should set storage_strict_mode to true when STORAGE_STRICT_MODE is true', () => {
+        config.setConfig({});
+        process.env.STORAGE_STRICT_MODE = 'true';
+
+        const _config = config.getConfig();
+        assert.strictEqual(_config.storage_strict_mode, 'true');
     })
 })
-

--- a/test/data/config.test.json
+++ b/test/data/config.test.json
@@ -1,5 +1,6 @@
 {
     "storageCredentials": {
+        "type": "SharedKey",
         "accountName": "whateverAccountName",
         "accountKey": "whateverAccountKey"
     },

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -8,8 +8,16 @@ const _rendersContainer = 'renders-container';
 const _templatesContainer = 'templates-container';
 
 const pathFileTxt = path.join(__dirname, 'data', 'file.txt');
+const urlBlobStorage = 'https://whateveraccountname.blob.core.windows.net';
 
-const urlBlobStorage = 'https://whateverAccountName.blob.core.windows.net';
+function blobDownloadHeaders(body) {
+    return {
+        'content-length': Buffer.byteLength(body).toString(),
+        'content-type': 'application/octet-stream',
+        'x-ms-blob-type': 'BlockBlob',
+        'etag': '"0x8DD000000000001"'
+    };
+}
 
 describe('Storage', () => {
     let storage = null;
@@ -18,6 +26,7 @@ describe('Storage', () => {
 
         config.setConfig({
             storageCredentials: {
+                type: 'SharedKey',
                 accountName: 'whateverAccountName',
                 accountKey: 'whateverAccountKey'
             },
@@ -28,47 +37,57 @@ describe('Storage', () => {
         });
 
         nock(urlBlobStorage)
-            .intercept(`/${_templatesContainer}`, "HEAD")
-            .reply(200);
+            .put(uri => uri.includes(`/${_templatesContainer}/test%20template%20`))
+            .reply(201);
 
         nock(urlBlobStorage)
-            .intercept(`/${_rendersContainer}`, "HEAD")
-            .reply(200);
+            .delete(uri => uri.includes(`/${_templatesContainer}/test%20template%20`))
+            .reply(202);
+
+        nock(urlBlobStorage)
+            .put(uri => uri.includes(`/${_rendersContainer}/test%20render%20`))
+            .reply(201);
+
+        nock(urlBlobStorage)
+            .delete(uri => uri.includes(`/${_rendersContainer}/test%20render%20`))
+            .reply(202);
 
         storage = require('../storage');
     });
 
     describe('writeTemplate', () => {
 
-        it('should write template on blob storage', () => {
+        it('should write template on blob storage', (done) => {
             nock(urlBlobStorage)
                 .put(uri => uri.includes(`/${_templatesContainer}/templateId`))
-                .reply(200);
+                .reply(201);
 
             storage.writeTemplate({}, {}, 'templateId', pathFileTxt, (err, templateName) => {
                 assert.strictEqual(err, null);
                 assert.strictEqual(templateName, 'templateId');
+                done();
             });
         })
 
-        it('should return AccessDenied error if not authorized to write file on blob storage', () => {
+        it('should return AccessDenied error if not authorized to write file on blob storage', (done) => {
             nock(urlBlobStorage)
                 .put(uri => uri.includes(`/${_templatesContainer}/templateId`))
-                .reply(403);
+                .reply(403, '', { 'x-ms-error-code': 'AuthorizationFailure' });
 
             storage.writeTemplate({}, {}, 'templateId', pathFileTxt, (err) => {
-                assert.strictEqual(err.toString().includes(403), true);
-                assert.strictEqual(err.toString().includes('AccessDenied'), true);
+                assert.strictEqual(err.statusCode, 403);
+                done();
             });
         });
 
-        it('should return an error if file cannot be written on blob storage', () => {
+        it('should return an error if file cannot be written on blob storage', (done) => {
             nock(urlBlobStorage)
                 .put(uri => uri.includes(`/${_templatesContainer}/templateId`))
-                .replyWithError('Server unavailable');
+                .reply(400, '', { 'x-ms-error-code': 'InvalidHeaderValue' });
 
             storage.writeTemplate({}, {}, 'templateId', pathFileTxt, (err) => {
-                assert.strictEqual(err.toString(), 'reson: Server unavailable');
+                assert.strictEqual(err.statusCode, 400);
+                done();
             });
         });
     })
@@ -84,50 +103,60 @@ describe('Storage', () => {
                     fs.unlinkSync(filePath);
                 }
             }
+            toDelete.length = 0;
         });
 
-        it('should read the template from blob storage', () => {
-            nock(urlBlobStorage)
-                .get(uri => uri.includes(`/${_templatesContainer}/`))
-                .reply(200, () => {
-                    return fs.createReadStream(pathFileTxt);
-                });
+        it('should read the template from blob storage', (done) => {
+            const templateId = 'template.odt';
+            const templatePath = path.join(__dirname, 'data', templateId);
 
-            storage.readTemplate({}, {}, 'template.odt', (err, templatePath) => {
+            if (fs.existsSync(templatePath)) {
+                fs.unlinkSync(templatePath);
+            }
+
+            nock(urlBlobStorage)
+                .get(uri => uri.includes(`/${_templatesContainer}/${templateId}`))
+                .reply(200, 'Some content.\n', blobDownloadHeaders('Some content.\n'));
+
+            storage.readTemplate({}, {}, templateId, (err, downloadedTemplatePath) => {
                 assert.strictEqual(err, null);
-                assert.strictEqual(path.basename(templatePath), 'template.odt');
-                assert.strictEqual(fs.existsSync(templatePath), true);
-                assert.strictEqual(fs.readFileSync(templatePath, 'utf8'), 'Some content.\n');
-                toDelete.push(path.basename(templatePath));
+                assert.strictEqual(path.basename(downloadedTemplatePath), templateId);
+                assert.strictEqual(fs.existsSync(downloadedTemplatePath), true);
+                assert.strictEqual(fs.readFileSync(downloadedTemplatePath, 'utf8'), 'Some content.\n');
+                toDelete.push(path.basename(downloadedTemplatePath));
+                done();
             });
         });
 
-        it('should return NotFound error if file does not exist on blob storage', () => {
+        it('should return NotFound error if file does not exist on blob storage', (done) => {
             nock(urlBlobStorage)
-                .get(uri => uri.includes(`/${_templatesContainer}/`))
-                .reply(404);
+                .get(uri => uri.includes(`/${_templatesContainer}/missing-template.odt`))
+                .reply(404, '', { 'x-ms-error-code': 'BlobNotFound' });
 
-            storage.readTemplate({}, {}, 'template.odt', (err) => {
-                assert.strictEqual(err.toString().includes(404), true);
+            storage.readTemplate({}, {}, 'missing-template.odt', (err) => {
+                assert.strictEqual(err.statusCode, 404);
+                done();
             });
         });
 
-        it('should return an error if file cannot be read from blob', () => {
+        it('should return an error if file cannot be read from blob', (done) => {
             nock(urlBlobStorage)
-                .get(uri => uri.includes(`/${_templatesContainer}/`))
-                .replyWithError('Server unavailable');
+                .get(uri => uri.includes(`/${_templatesContainer}/invalid-template.odt`))
+                .reply(400, '', { 'x-ms-error-code': 'InvalidHeaderValue' });
 
-            storage.readTemplate({}, {}, 'template.odt', (err) => {
-                assert.strictEqual(err.toString(), 'reson: Server unavailable');
+            storage.readTemplate({}, {}, 'invalid-template.odt', (err) => {
+                assert.strictEqual(err.statusCode, 400);
+                done();
             });
         });
 
-        it('should not call the blob storage if file already exists in local folder', () => {
+        it('should not call the blob storage if file already exists in local folder', (done) => {
             const expectedPath = path.join('test', 'data', 'file.txt');
 
             storage.readTemplate({}, {}, 'file.txt', (err, templatePath) => {
                 assert.strictEqual(err, null);
                 assert.strictEqual(templatePath.endsWith(expectedPath), true);
+                done();
             });
         });
     })
@@ -146,48 +175,43 @@ describe('Storage', () => {
             }
         });
 
-        it('should delete the template from blob storage', () => {
+        it('should delete the template from blob storage', (done) => {
             nock(urlBlobStorage)
                 .delete(uri => uri.includes(`/${_templatesContainer}`))
-                .reply(200);
+                .reply(202);
 
-            const res = {
-                send(result) {
-                    assert.deepStrictEqual(result, {
-                        success: true,
-                        message: 'Template deleted'
-                    });
-                }
-            };
+            const res = {};
 
-            storage.deleteTemplate({}, res, 'template.docx', (err, templatePath) => {
+            storage.deleteTemplate({}, res, 'template.docx', (err, deletedTemplatePath) => {
                 assert.strictEqual(err, null);
-                assert.strictEqual(templatePath.endsWith('/test/data/template.docx'), true);
+                assert.strictEqual(deletedTemplatePath.endsWith(path.join('test', 'data', 'template.docx')), true);
+                done();
             });
         });
 
-        it('should return AccessDenied error if not authorized to delete from blob storage', () => {
+        it('should return AccessDenied error if not authorized to delete from blob storage', (done) => {
             nock(urlBlobStorage)
                 .delete(uri => uri.includes(`/${_templatesContainer}`))
-                .reply(403);
+                .reply(403, '', { 'x-ms-error-code': 'AuthorizationFailure' });
 
             const res = {};
 
             storage.deleteTemplate({}, res, path.join('..', 'test', 'datas', 'template.docx'), (err) => {
-                assert.strictEqual(err.toString().includes(403), true);
-                assert.strictEqual(err.toString().includes('AccessDenied'), true);
+                assert.strictEqual(err.statusCode, 403);
+                done();
             });
         });
 
-        it("should return an error if file cannot be deleted from blob storage", () => {
+        it("should return an error if file cannot be deleted from blob storage", (done) => {
             nock(urlBlobStorage)
                 .delete(uri => uri.includes(`/${_templatesContainer}`))
-                .replyWithError('Server Unavailable');
+                .reply(400, '', { 'x-ms-error-code': 'InvalidHeaderValue' });
 
             const res = {};
 
             storage.deleteTemplate({}, res, path.join('..', 'test', 'data', 'template.docx'), (err) => {
-                assert.strictEqual(err.toString(), 'reson: Server unavailable');
+                assert.strictEqual(err.statusCode, 400);
+                done();
             });
         });
     });
@@ -197,50 +221,54 @@ describe('Storage', () => {
         const _renderName = "whatever.pdf";
         const _expectedFilename = path.basename(pathFileTxt);
 
-        it('should save the generated doccument into the renders container', () => {
+        it('should save the generated doccument into the renders container', (done) => {
             nock(urlBlobStorage)
-                .put(uri => uri.includes(`/${_rendersContainer}/${_renderName}`))
-                .reply(200);
+                .put(uri => uri.includes(`/${_rendersContainer}/${_expectedFilename}`))
+                .reply(201);
 
             storage.afterRender({}, {}, null, pathFileTxt, _renderName, {}, (err) => {
                 assert.strictEqual(err, undefined);
+                done();
             });
         });
 
-        it('should save a generated doccument into the renders containers even if the filename is not provided', () => {
+        it('should save a generated doccument into the renders containers even if the filename is not provided', (done) => {
             nock(urlBlobStorage)
                 .put(uri => uri.includes(`/${_rendersContainer}/${_expectedFilename}`))
-                .reply(200);
+                .reply(201);
 
             storage.afterRender({}, {}, null, pathFileTxt, '', {}, (err) => {
                 assert.strictEqual(err, undefined);
+                done();
             });
         });
 
-        it('should return an error if the rendering fails', () => {
+        it('should return an error if the rendering fails', (done) => {
             storage.afterRender({}, {}, new Error('Something went wrong'), pathFileTxt, _renderName, {}, (err) => {
                 assert.strictEqual(err.toString(), 'Error: Something went wrong');
+                done();
             });
         });
 
-        it('should return AccessDenied error if not authorized to save into the blob storage', () => {
+        it('should return AccessDenied error if not authorized to save into the blob storage', (done) => {
             nock(urlBlobStorage)
-                .put(uri => uri.includes(`/${_rendersContainer}/${_renderName}`))
-                .reply(403);
+                .put(uri => uri.includes(`/${_rendersContainer}/${_expectedFilename}`))
+                .reply(403, '', { 'x-ms-error-code': 'AuthorizationFailure' });
 
             storage.afterRender({}, {}, null, pathFileTxt, _renderName, {}, (err) => {
-                assert.strictEqual(err.toString().includes(403), true);
-                assert.strictEqual(err.toString().includes('AccessDenied'), true);
+                assert.strictEqual(err.statusCode, 403);
+                done();
             });
         });
 
-        it('should return an error if the blob storage is not available', () => {
+        it('should return an error if the blob storage is not available', (done) => {
             nock(urlBlobStorage)
-                .put(uri => uri.includes(`/${_rendersContainer}/${_renderName}`))
-                .replyWithError('Server Unavailable');
+                .put(uri => uri.includes(`/${_rendersContainer}/${_expectedFilename}`))
+                .reply(400, '', { 'x-ms-error-code': 'InvalidHeaderValue' });
 
             storage.afterRender({}, {}, null, pathFileTxt, _renderName, {}, (err) => {
-                assert.strictEqual(err.toString(), 'reason: Server Unavailable');
+                assert.strictEqual(err.statusCode, 400);
+                done();
             });
         });
     });
@@ -255,9 +283,10 @@ describe('Storage', () => {
                     fs.unlinkSync(toDelete[i]);
                 }
             }
+            toDelete.length = 0;
         });
 
-        it('should download the generated document from the cache folder and delete the file from blob storage', () => {
+        it('should download the generated document from the cache folder and delete the file from blob storage', (done) => {
 
             const _renderName = 'whatever.pdf'
 
@@ -265,74 +294,79 @@ describe('Storage', () => {
 
             nock(urlBlobStorage)
                 .delete(uri => uri.includes(`/${_rendersContainer}/${_renderName}`))
-                .reply(200);
+                .reply(202);
 
             storage.readRender({}, {}, _renderName, (err, renderPath) => {
                 assert.strictEqual(null, err);
-                assert.strictEqual(renderPath.includes('data/' + _renderName), true)
+                assert.strictEqual(renderPath.includes(path.join('data', _renderName)), true)
                 toDelete.push(renderPath);
+                done();
             });
         });
 
-        it('should download the generated document and delete it from blob storage', () => {
+        it('should download the generated document and delete it from blob storage', (done) => {
 
-            const _renderName = 'whatever.pdf';
+            const _renderName = 'downloaded.pdf';
+            const _renderPath = path.join(__dirname, 'data', _renderName);
+
+            if (fs.existsSync(_renderPath)) {
+                fs.unlinkSync(_renderPath);
+            }
 
             nock(urlBlobStorage)
                 .get(uri => uri.includes(`/${_rendersContainer}/${_renderName}`))
-                .reply(200, () => {
-                    return fs.createReadStream(pathFileTxt);
-                });
+                .reply(200, 'Some content.\n', blobDownloadHeaders('Some content.\n'));
 
             nock(urlBlobStorage)
                 .delete(uri => uri.includes(`/${_rendersContainer}/${_renderName}`))
-                .reply(200);
+                .reply(202);
 
             storage.readRender({}, {}, _renderName, (err, renderPath) => {
                 assert.strictEqual(null, err);
-                assert.strictEqual(renderPath.includes('datasets/' + _renderName), true)
+                assert.strictEqual(renderPath.includes(path.join('data', _renderName)), true)
                 toDelete.push(renderPath);
+                done();
             });
         });
 
-        it('should return an error if the file does not exist', () => {
+        it('should return an error if the file does not exist', (done) => {
 
-            const _renderName = 'whatever.pdf';
+            const _renderName = 'missing.pdf';
 
             nock(urlBlobStorage)
                 .get(uri => uri.includes(`/${_rendersContainer}/${_renderName}`))
-                .reply(404);
+                .reply(404, '', { 'x-ms-error-code': 'BlobNotFound' });
 
-            storage.readRender({}, {}, _renderName, (err, renderPath) => {
-                assert.strictEqual('Error: File does not exist', err.toString());
+            storage.readRender({}, {}, _renderName, (err) => {
+                assert.strictEqual(err.toString().includes('Error downloading blob'), true);
+                done();
             });
         });
 
-        it('should return AccessDenied if not authorized to read from blob storage', () => {
-            const _renderName = 'whatever.pdf';
+        it('should return AccessDenied if not authorized to read from blob storage', (done) => {
+            const _renderName = 'forbidden.pdf';
 
             nock(urlBlobStorage)
                 .get(uri => uri.includes(`/${_rendersContainer}/${_renderName}`))
-                .reply(403);
+                .reply(403, '', { 'x-ms-error-code': 'AuthorizationFailure' });
 
-            storage.readRender({}, {}, _renderName, (err, renderPath) => {
-                assert.strictEqual(err.toString().includes(403), true);
-                assert.strictEqual(err.toString().includes('AccessDenied'), true);
+            storage.readRender({}, {}, _renderName, (err) => {
+                assert.strictEqual(err.toString().includes('Error downloading blob'), true);
+                done();
             });
         });
 
-        it('should return an error if the blob storage is not available', () => {
-            const _renderName = 'whatever.pdf';
+        it('should return an error if the blob storage is not available', (done) => {
+            const _renderName = 'invalid.pdf';
 
             nock(urlBlobStorage)
                 .get(uri => uri.includes(`/${_rendersContainer}/${_renderName}`))
-                .replyWithError('Server Unavailable');
+                .reply(400, '', { 'x-ms-error-code': 'InvalidHeaderValue' });
 
-            storage.readRender({}, {}, _renderName, (err, renderPath) => {
-                assert.strictEqual(err.toString(), 'reason: Server Unavailable');
+            storage.readRender({}, {}, _renderName, (err) => {
+                assert.strictEqual(err.toString().includes('Error downloading blob'), true);
+                done();
             });
         });
     })
 })
-
-


### PR DESCRIPTION
Support any emulator using the `AZURE_STORAGE_CONNECTION_STRING` env variable and the `BlobServiceClient.fromConnectionString` overload.

Support the Default Azure Emulator with the `AZURE_USE_DEFAULT_AZURE_CREDENTIALS="true"` env variable. It allows additional authentication methods between the already supported SharedKey & Managed identities, through [these additional env variables](https://learn.microsoft.com/en-us/javascript/api/overview/azure/identity-readme?view=azure-node-latest#environment-variables).

Fix the storage tests that were not awaited and produces unreliable results.

The `package-lock.json` file has been source controlled too for improved reliability and security, forbidding the execution of untested dependencies in the CI pipelines.

The documentation has been updated too.