### PR TITLE
Do not save into storage when document is directly downloaded

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -281,7 +281,13 @@ function afterRender(req, res, err, reportPath, reportName, stats, callback) {
   if (err) {
     return callback(err);
   }
+  
   if (!_config?.rendersContainer) {
+    return callback();
+  }
+
+  if (req.query?.download === 'true') {
+    // direct downloads renders should not be saved in the storage.
     return callback();
   }
 

--- a/test/storage.test.js
+++ b/test/storage.test.js
@@ -243,6 +243,15 @@ describe('Storage', () => {
             });
         });
 
+        it('should skip saving to blob storage for direct download renders (?download=true)', (done) => {
+            const req = { path: '/render/whatever.pdf', query: { download: 'true' } };
+            storage.afterRender(req, {}, null, pathFileTxt, _renderName, {}, (err) => {
+                assert.strictEqual(err, undefined);
+                // No need to assert anything additional: if a call is actually attempted to the storage, it would throw.
+                done();
+            });
+        });
+
         it('should return an error if the rendering fails', (done) => {
             storage.afterRender({}, {}, new Error('Something went wrong'), pathFileTxt, _renderName, {}, (err) => {
                 assert.strictEqual(err.toString(), 'Error: Something went wrong');


### PR DESCRIPTION
When a render is executed with `download=true`, the plugin saves the document to the storage.

The issue is that since Carbone has no reference to this file locally, because `download=true` does not save it, the storage file is kept forever.

This change disables the upload to the storage when `download` is `true`